### PR TITLE
Using correct SHOW TABLES LIKE sql syntax

### DIFF
--- a/index.php
+++ b/index.php
@@ -202,7 +202,7 @@ if(!class_exists('MemberMouseGroupAddon')){
 			$table_group_item 	= $wpdb -> prefix.'group_items';
 			$table_group_notice	= $wpdb -> prefix.'group_notices';
 			
-            if($wpdb -> get_var( "show tables like $table_name" ) != $table_name):
+            if($wpdb -> get_var( "SHOW TABLES LIKE '$table_name'" ) != $table_name):
 				$sql = "CREATE TABLE IF NOT EXISTS $table_name (
                     id INT(11) NOT NULL AUTO_INCREMENT,
                     group_template_id INT(11) NOT NULL DEFAULT '0',
@@ -217,7 +217,7 @@ if(!class_exists('MemberMouseGroupAddon')){
 				dbDelta($sql);
 			endif;
 			
-			if($wpdb -> get_var( "show tables like $table_name1" ) != $table_name1):
+			if($wpdb -> get_var( "SHOW TABLES LIKE '$table_name1'" ) != $table_name1):
 				$sql = "CREATE TABLE IF NOT EXISTS $table_name1 (
                     id INT(11) NOT NULL AUTO_INCREMENT,
                     group_id INT(11) NOT NULL DEFAULT '0',
@@ -229,7 +229,7 @@ if(!class_exists('MemberMouseGroupAddon')){
 				dbDelta($sql);
 			endif;
 			
-			if($wpdb -> get_var( "show tables like $table_group_item" ) != $table_group_item):
+			if($wpdb -> get_var( "SHOW TABLES LIKE '$table_group_item'" ) != $table_group_item):
 				$sql = "CREATE TABLE IF NOT EXISTS $table_group_item (
                     id INT(11) NOT NULL AUTO_INCREMENT,
                     name VARCHAR(255) NOT NULL,
@@ -246,7 +246,7 @@ if(!class_exists('MemberMouseGroupAddon')){
 				dbDelta($sql);
 			endif;
 			
-			if($wpdb -> get_var( "show tables like $table_group_notice" ) != $table_group_notice):
+			if($wpdb -> get_var( "SHOW TABLES LIKE '$table_group_notice'" ) != $table_group_notice):
 				$sql = "CREATE TABLE IF NOT EXISTS $table_group_notice(
                     id INT(11) NOT NULL AUTO_INCREMENT,
                     group_id INT(11) NOT NULL DEFAULT '0',


### PR DESCRIPTION
Resolves the following database errors in `debug.log` related to checking if a table exists before table creation on plugin activation. Need to wrap the table name in single quotes.

```
[13-Feb-2018 03:00:57 UTC] WordPress database error You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'wp_group_sets' at line 1 for query show tables like wp_group_sets made by activate_plugin, do_action('activate_MemberMouseGroupAddon/index.php'), WP_Hook->do_action, WP_Hook->apply_filters, call_user_func_array, MemberMouseGroupAddon->MemberMouseGroupAddonActivate, MemberMouseGroupAddon->MemberMouseGroupAddonCreateTables
[13-Feb-2018 03:00:57 UTC] WordPress database error You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'wp_group_sets_members' at line 1 for query show tables like wp_group_sets_members made by activate_plugin, do_action('activate_MemberMouseGroupAddon/index.php'), WP_Hook->do_action, WP_Hook->apply_filters, call_user_func_array, MemberMouseGroupAddon->MemberMouseGroupAddonActivate, MemberMouseGroupAddon->MemberMouseGroupAddonCreateTables
[13-Feb-2018 03:00:57 UTC] WordPress database error You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'wp_group_items' at line 1 for query show tables like wp_group_items made by activate_plugin, do_action('activate_MemberMouseGroupAddon/index.php'), WP_Hook->do_action, WP_Hook->apply_filters, call_user_func_array, MemberMouseGroupAddon->MemberMouseGroupAddonActivate, MemberMouseGroupAddon->MemberMouseGroupAddonCreateTables
[13-Feb-2018 03:00:57 UTC] WordPress database error You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'wp_group_notices' at line 1 for query show tables like wp_group_notices made by activate_plugin, do_action('activate_MemberMouseGroupAddon/index.php'), WP_Hook->do_action, WP_Hook->apply_filters, call_user_func_array, MemberMouseGroupAddon->MemberMouseGroupAddonActivate, MemberMouseGroupAddon->MemberMouseGroupAddonCreateTables
```